### PR TITLE
Center author names in main page

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -407,10 +407,9 @@ footer {
         margin-right: 3%;
         margin-top: 5px;
         .post-author-name{
-          text-align: left;
+          text-align: center;
           display: block;
           margin-top: 10px;
-          margin-left: 30px;
           font-size: 1.1em;
 
           a {


### PR DESCRIPTION
It was ugly to see that when viewing altogether.

Before & after:

![image](https://user-images.githubusercontent.com/3905501/27239251-86b32686-52a6-11e7-979d-860cbd4bbad4.png)
