### PR TITLE
Pagination, go up button and fixes to the design

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: ruby
-# only run CI-builds on master branch
-branches:
-  only:
-  - master
 rvm:
 - 2.3.0
-# set execution permission on our build script
-before_script:
- - chmod +x ./script/cibuild
-# path to our build script.
-# Travis will run `bundle install` by default before running our script
-script: ./script/cibuild
-exclude: [vendor]
-sudo: false
+install:
+- bundle install
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: _site
+  target_branch: gh-pages
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+# only run CI-builds on master branch
+branches:
+  only:
+  - master
+rvm:
+- 2.3.0
+# set execution permission on our build script
+before_script:
+ - chmod +x ./script/cibuild
+# path to our build script.
+# Travis will run `bundle install` by default before running our script
+script: ./script/cibuild
+exclude: [vendor]
+sudo: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+ruby '2.3.0'
+
+# rake to build our site in TravisCI
+gem "rake", "~> 12"
+gem "jekyll"
+
+# Add any custom plugins here.
+group :jekyll_plugins do
+  gem "jekyll-paginate-v2"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,71 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    colorator (1.1.0)
+    concurrent-ruby (1.1.3)
+    em-websocket (0.5.1)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0.6.0)
+    eventmachine (1.2.7)
+    ffi (1.9.25)
+    forwardable-extended (2.6.0)
+    http_parser.rb (0.6.0)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    jekyll (3.8.5)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      em-websocket (~> 0.5)
+      i18n (~> 0.7)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 2.0)
+      kramdown (~> 1.14)
+      liquid (~> 4.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (>= 1.7, < 4)
+      safe_yaml (~> 1.0)
+    jekyll-paginate-v2 (2.0.0)
+      jekyll (~> 3.0)
+    jekyll-sass-converter (1.5.2)
+      sass (~> 3.4)
+    jekyll-watch (2.1.2)
+      listen (~> 3.0)
+    kramdown (1.17.0)
+    liquid (4.0.1)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
+    mercenary (0.3.6)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (3.0.3)
+    rake (12.3.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (3.3.0)
+    ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
+    sass (3.7.2)
+      sass-listen (~> 4.0.0)
+    sass-listen (4.0.0)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-paginate-v2
+  rake (~> 12)
+
+RUBY VERSION
+   ruby 2.3.0p0
+
+BUNDLED WITH
+   1.17.1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Xmartlabs Blog
+The idea of this blog is to post some insights of our work and share tips and data related to the projects we tackle.
+We will also keep it updated with info and news about Xmartlabs.
+
+## Contents
+
+* [Local setup]
+* [Featured posts]
+
+## Local setup
+This blog was built using [Jekyll](https://jekyllrb.com), a simple, extendable and static site generator.
+To set it up on your machine:
+1. Clone the project into your machine: git clone git@github.com:xmartlabs/blog.git
+2. Create your branch: `git checkout -b my-new-branch`
+3. Install Ruby 2.3.0 (you can use [rbenv](https://github.com/rbenv/rbenv))
+4. Install Jekyll and bundler in this Ruby version by running: `gem install jekyll bundler`
+5. Go to the folder for this repository and build the site with `jekyll serve` or `jekyll serve --host=0.0.0.0` (if you want to use it from your phone or other machine)
+6. Now browse to http://localhost:4000 or http://YOUR-IP:4000
+
+## Featured posts
+If you will like for your post to be among the 3 featured posts you will need to set the following variables in the post [front matter](https://jekyllrb.com/docs/front-matter/):
+- `featured_position: 1`
+This may take one of the following values:
+    - `1`: it will be displayed on the left column in Desktop, the image size needs to be around 574x385px
+    - `2`: it will be display at the top of the right column in Desktop, the image size needs to be around 706x187px
+    - `3`: it will be display at the bottom of the right column in Desktop, the image size needs to be around 706x187px
+- `featured_image: /images/my-new-post/featured.png`
+Remeber to place the image inside the folder created for your post, you might use a different name and format, just write the correct path in the variable.
+
+**IMPORTANT:**
+If multiple posts have the same `featured_position` the newest will show on the featured section but the others won't show on the list of posts (since this are filtered to avoid repetition). **Please avoid this by deleting these variables from the post you want to replace.**

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,9 @@
+task :default do
+  puts "Running CI tasks..."
+
+  # Runs the jekyll build command for production
+  # TravisCI will now have a site directory with our
+  # statically generated files.
+  sh("JEKYLL_ENV=production bundle exec jekyll build")
+  puts "Jekyll successfully built"
+end

--- a/_config.yml
+++ b/_config.yml
@@ -19,8 +19,20 @@ future: false
 timezone: America/Montevideo
 permalink: /:year/:month/:day/:title/
 
-# sass:
-#   style: :compressed
+plugins: [jekyll-paginate-v2]
+
+plugins_dir:
+  - jekyll-paginate-v2
+
+# Pagination Settings
+pagination:
+  enabled: true
+  per_page: 12
+  permalink: '/page/:num/'
+  title: ':title - page :num of :max'
+  limit: 0
+  sort_field: 'date'
+  sort_reverse: true
 
 defaults:
   # Default layout and language to everything

--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,10 @@ defaults:
       type: "posts"
     values:
       author: "mtnBarreto"
+
+exclude:
+  - vendor
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - Rakefile

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,0 +1,26 @@
+<article class="post-item">
+  <a href="{{ post.url | prepend: site.baseurl }}">
+    <div class="post-info">
+      <h1 class="post-title">
+        {{ post.title }}
+      </h1>
+      <div class="post-time-info visible-xs">
+        <time class="post-meta" datetime="{{ post.date }}">
+          {{ post.date | date: "%b %-d, %Y" }}
+        </time>
+      </div>
+      <p class="paragraph">
+        {{ post.content | truncatewords:20 | strip_html}}
+      </p>
+      <p class="read-more"> Read more </p>
+    </div>
+
+    <div class="post-time-info hidden-xs">
+      <time class="post-meta" datetime="{{ post.date }}">
+        {{ post.date | date: "%b %-d, %Y" }}
+      </time>
+    </div>
+    <div class="clear">
+    </div>
+  </a>
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -71,4 +71,5 @@ layout: default
       </div>
     </div>
   </div>
+  <a href="#" id="goToTop"><span>▲</span></a>
 </article>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -121,6 +121,9 @@ div.header {
       margin-bottom: 20px;
     }
   }
+  >li:last-child {
+    margin-bottom: 20px;
+  }
   article {
     display: block;
     padding: 30px 50px;
@@ -141,6 +144,7 @@ div.header {
       word-break: break-word;
       h1.post-title {
         margin-top: 4px;
+        color: $black;
         @include media-query($on-palm) {
           margin-bottom: 5px;
         }
@@ -409,6 +413,9 @@ div.header {
       padding-bottom: 0.25em;
       list-style-type: disc;
     }
+    @include media-query($on-palm) {
+      padding-left: 0;
+    }
   }
   ol {
     list-style-type: decimal;
@@ -416,11 +423,15 @@ div.header {
     &.alphabetical {
       list-style-type: lower-alpha;
     }
+    @include media-query($on-palm) {
+      padding-left: 0;
+    }
   }
 }
 
 code {
   display: inline-block !important;
+  white-space: normal;
 }
 
 pre code {
@@ -437,5 +448,46 @@ div.post_container a {
   @include media-query($md-width) {
     padding-left: 20px;
     padding-right: 20px;
+  }
+}
+
+ul.pager {
+  padding-left: 0;
+  margin-left: 0;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 20px;
+
+  li {
+    font-family: $body;
+    font-size: 1.4em;
+    font-weight: 300;
+    letter-spacing: .02em;
+    a {
+      color: $pink;
+    }
+  }
+}
+
+#goToTop {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  cursor: pointer;
+  width: 50px;
+  height: 50px;
+  background-color: $pink;
+  display: none;
+  -webkit-border-radius: 60px;
+  -moz-border-radius: 60px;
+  border-radius: 60px;
+  justify-content: center;
+  align-items: center;
+  color: $white;
+  font-family: $body;
+  font-size: 2em;
+
+  span {
+    padding-bottom: 5px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1,8 +1,10 @@
 ---
 layout: default
+pagination:
+  enabled: true
 ---
 {% include featured.html %}
-    
+
 <div class="page-content">
   <div class="wrapper">
     <div class="home">
@@ -10,38 +12,28 @@ layout: default
       </h1>
       <section>
         <ul class="post-list">
-          {% for post in site.posts %}
+          {% for post in paginator.posts %}
+            {% unless post.featured_position %}
             <li>
-              <article class="post-item {{ post.author_id }}">
-
-                <div class="post-info">
-                  <h1 class="post-title">
-                    <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-                  </h1>
-                  <div class="post-time-info visible-xs">
-                    <time class="post-meta" datetime="{{ post.date }}">
-                      {{ post.date | date: "%b %-d, %Y" }}
-                    </time>
-                  </div>
-                  <p class="paragraph">
-                    {{ post.content | truncatewords:20 | strip_html}}
-                  </p>
-                  <a href="{{ post.url | prepend: site.baseurl }}" class="read-more"> Read more </a>
-                </div>
-
-                <div class="post-time-info hidden-xs">
-                  <time class="post-meta" datetime="{{ post.date }}">
-                    {{ post.date | date: "%b %-d, %Y" }}
-                  </time>
-                </div>
-
-                <div class="clear">
-                </div>
-
-              </article>
+              {% include post.html post=post %}
             </li>
+            {% endunless %}
           {% endfor %}
         </ul>
+        {% if paginator.total_pages > 1 %}
+        <ul class="pager">
+          <li class="previous">
+            {% if paginator.previous_page %}
+            <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&larr; Newer Posts</a>
+            {% endif %}
+          </li>
+          <li class="next">
+            {% if paginator.next_page %}
+            <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Previous Posts &rarr;</a>
+            {% endif %}
+          </li>
+        </ul>
+        {% endif %}
       </section>
     </div>
   </div>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,27 @@ function turnTargetBlankForExternalLinks() {
   }
 }
 
+function showGoToTop() {
+  $(window).scroll(function(){
+    if ($(this).width() <= 620 && $(this).scrollTop() > 100) {
+      if($('#goToTop').is(":hidden")) {
+        $('#goToTop').css({display: "flex"}).hide().fadeIn();
+      }
+    } else {
+      $('#goToTop').fadeOut();
+    }
+  });
+}
+
 $(document).ready(function() {
   turnTargetBlankForExternalLinks();
+
+  if($('#goToTop').length > 0){
+    showGoToTop();
+  }
+
+  $('#goToTop').click(function(){
+    $("html, body").animate({ scrollTop: 0 }, 600);
+    return false;
+  });
 });


### PR DESCRIPTION
_The Travis setup is on its way, it's needed since [the pagination plugin isn't supported by GitHub Pages](https://ayastreb.me/deploy-jekyll-to-github-pages-with-travis-ci/)_

**Fixes:**
- Remove horizontal scrolling on mobile that happens due to code sections (for example: [Introducing Fountain Part Two](https://blog.xmartlabs.com/2018/08/20/Introducing-Fountain-Part-Two/))

**Features:**
- Pagination with [jekyll-paginate-v2](https://github.com/sverrirs/jekyll-paginate-v2)
![screen shot 2018-12-03 at 15 01 54](https://user-images.githubusercontent.com/15196342/49396061-f8c80780-f716-11e8-8d68-fe05a87e0849.png)
- Go to top button on mobile
![screen shot 2018-12-03 at 15 03 53](https://user-images.githubusercontent.com/15196342/49396079-01b8d900-f717-11e8-9585-9e99a93c78f1.png)
- README to explain local setup and how to change the featured posts

