### PR TITLE
Go to button and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Xmartlabs Blog
-The idea of this blog is to post some insights of our work and share tips and data related to the projects we tackle.
+The purpose of this blog is to showcase some insight into our work and share data and tips related to the projects we tackle.
 We will also keep it updated with info and news about Xmartlabs.
 
 ## Contents
@@ -18,14 +18,14 @@ To set it up on your machine:
 6. Now browse to http://localhost:4000 or http://YOUR-IP:4000
 
 ## Featured posts
-If you will like for your post to be among the 3 featured posts you will need to set the following variables in the post [front matter](https://jekyllrb.com/docs/front-matter/):
+If you want a post to be among the 3 featured posts you need to set the following custom variables in its [front matter](https://jekyllrb.com/docs/front-matter/):
 - `featured_position: 1`
-This may take one of the following values:
+These may take one of the following values:
     - `1`: it will be displayed on the left column in Desktop, the image size needs to be around 574x385px
-    - `2`: it will be display at the top of the right column in Desktop, the image size needs to be around 706x187px
-    - `3`: it will be display at the bottom of the right column in Desktop, the image size needs to be around 706x187px
+    - `2`: it will be displayed at the top of the right column in Desktop, the image size needs to be around 706x187px
+    - `3`: it will be displayed at the bottom of the right column in Desktop, the image size needs to be around 706x187px
 - `featured_image: /images/my-new-post/featured.png`
-Remeber to place the image inside the folder created for your post, you might use a different name and format, just write the correct path in the variable.
+Remember to place the image inside the post's folder. A different name and format can be used, just assign the correct path to the variable.
 
 **IMPORTANT:**
-If multiple posts have the same `featured_position` the newest will show on the featured section but the others won't show on the list of posts (since this are filtered to avoid repetition). **Please avoid this by deleting these variables from the post you want to replace.**
+If multiple posts have the same `featured_position` the newest will show on the featured section but the others won't show on the list of posts (since these are filtered to avoid repetition). **Please avoid this by deleting these variables from the post you want to replace.**

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Xmartlabs Blog
+The idea of this blog is to post some insights of our work and share tips and data related to the projects we tackle.
+We will also keep it updated with info and news about Xmartlabs.
+
+## Contents
+
+* [Local setup]
+* [Featured posts]
+
+## Local setup
+This blog was built using [Jekyll](https://jekyllrb.com), a simple, extendable and static site generator.
+To set it up on your machine:
+1. Clone the project into your machine: git clone git@github.com:xmartlabs/blog.git
+2. Create your branch: `git checkout -b my-new-branch`
+3. Install Ruby 2.3.0 (you can use [rbenv](https://github.com/rbenv/rbenv))
+4. Install Jekyll and bundler in this Ruby version by running: `gem install jekyll bundler`
+5. Go to the folder for this repository and build the site with `jekyll serve` or `jekyll serve --host=0.0.0.0` (if you want to use it from your phone or other machine)
+6. Now browse to http://localhost:4000 or http://YOUR-IP:4000
+
+## Featured posts
+If you will like for your post to be among the 3 featured posts you will need to set the following variables in the post [front matter](https://jekyllrb.com/docs/front-matter/):
+- `featured_position: 1`
+This may take one of the following values:
+    - `1`: it will be displayed on the left column in Desktop, the image size needs to be around 574x385px
+    - `2`: it will be display at the top of the right column in Desktop, the image size needs to be around 706x187px
+    - `3`: it will be display at the bottom of the right column in Desktop, the image size needs to be around 706x187px
+- `featured_image: /images/my-new-post/featured.png`
+Remeber to place the image inside the folder created for your post, you might use a different name and format, just write the correct path in the variable.
+
+**IMPORTANT:**
+If multiple posts have the same `featured_position` the newest will show on the featured section but the others won't show on the list of posts (since this are filtered to avoid repetition). **Please avoid this by deleting these variables from the post you want to replace.**

--- a/_config.yml
+++ b/_config.yml
@@ -34,3 +34,6 @@ defaults:
       type: "posts"
     values:
       author: "mtnBarreto"
+
+exclude:
+  - README.md

--- a/_includes/post.html
+++ b/_includes/post.html
@@ -1,0 +1,26 @@
+<article class="post-item">
+  <a href="{{ post.url | prepend: site.baseurl }}">
+    <div class="post-info">
+      <h1 class="post-title">
+        {{ post.title }}
+      </h1>
+      <div class="post-time-info visible-xs">
+        <time class="post-meta" datetime="{{ post.date }}">
+          {{ post.date | date: "%b %-d, %Y" }}
+        </time>
+      </div>
+      <p class="paragraph">
+        {{ post.content | truncatewords:20 | strip_html}}
+      </p>
+      <p class="read-more"> Read more </p>
+    </div>
+
+    <div class="post-time-info hidden-xs">
+      <time class="post-meta" datetime="{{ post.date }}">
+        {{ post.date | date: "%b %-d, %Y" }}
+      </time>
+    </div>
+    <div class="clear">
+    </div>
+  </a>
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -71,4 +71,5 @@ layout: default
       </div>
     </div>
   </div>
+  <a href="#" id="goToTop"><span>▲</span></a>
 </article>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -121,6 +121,9 @@ div.header {
       margin-bottom: 20px;
     }
   }
+  >li:last-child {
+    margin-bottom: 20px;
+  }
   article {
     display: block;
     padding: 30px 50px;
@@ -141,6 +144,7 @@ div.header {
       word-break: break-word;
       h1.post-title {
         margin-top: 4px;
+        color: $black;
         @include media-query($on-palm) {
           margin-bottom: 5px;
         }
@@ -409,6 +413,9 @@ div.header {
       padding-bottom: 0.25em;
       list-style-type: disc;
     }
+    @include media-query($on-palm) {
+      padding-left: 0;
+    }
   }
   ol {
     list-style-type: decimal;
@@ -416,11 +423,15 @@ div.header {
     &.alphabetical {
       list-style-type: lower-alpha;
     }
+    @include media-query($on-palm) {
+      padding-left: 0;
+    }
   }
 }
 
 code {
   display: inline-block !important;
+  white-space: normal;
 }
 
 pre code {
@@ -437,5 +448,27 @@ div.post_container a {
   @include media-query($md-width) {
     padding-left: 20px;
     padding-right: 20px;
+  }
+}
+#goToTop {
+  position: fixed;
+  right: 10px;
+  bottom: 10px;
+  cursor: pointer;
+  width: 50px;
+  height: 50px;
+  background-color: $pink;
+  display: none;
+  -webkit-border-radius: 60px;
+  -moz-border-radius: 60px;
+  border-radius: 60px;
+  justify-content: center;
+  align-items: center;
+  color: $white;
+  font-family: $body;
+  font-size: 2em;
+
+  span {
+    padding-bottom: 5px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 {% include featured.html %}
-    
+
 <div class="page-content">
   <div class="wrapper">
     <div class="home">
@@ -11,35 +11,11 @@ layout: default
       <section>
         <ul class="post-list">
           {% for post in site.posts %}
+            {% unless post.featured_position %}
             <li>
-              <article class="post-item {{ post.author_id }}">
-
-                <div class="post-info">
-                  <h1 class="post-title">
-                    <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a>
-                  </h1>
-                  <div class="post-time-info visible-xs">
-                    <time class="post-meta" datetime="{{ post.date }}">
-                      {{ post.date | date: "%b %-d, %Y" }}
-                    </time>
-                  </div>
-                  <p class="paragraph">
-                    {{ post.content | truncatewords:20 | strip_html}}
-                  </p>
-                  <a href="{{ post.url | prepend: site.baseurl }}" class="read-more"> Read more </a>
-                </div>
-
-                <div class="post-time-info hidden-xs">
-                  <time class="post-meta" datetime="{{ post.date }}">
-                    {{ post.date | date: "%b %-d, %Y" }}
-                  </time>
-                </div>
-
-                <div class="clear">
-                </div>
-
-              </article>
+              {% include post.html post=post %}
             </li>
+            {% endunless %}
           {% endfor %}
         </ul>
       </section>

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,27 @@ function turnTargetBlankForExternalLinks() {
   }
 }
 
+function showGoToTop() {
+  $(window).scroll(function(){
+    if ($(this).width() <= 620 && $(this).scrollTop() > 100) {
+      if($('#goToTop').is(":hidden")) {
+        $('#goToTop').css({display: "flex"}).hide().fadeIn();
+      }
+    } else {
+      $('#goToTop').fadeOut();
+    }
+  });
+}
+
 $(document).ready(function() {
   turnTargetBlankForExternalLinks();
+
+  if($('#goToTop').length > 0){
+    showGoToTop();
+  }
+
+  $('#goToTop').click(function(){
+    $("html, body").animate({ scrollTop: 0 }, 600);
+    return false;
+  });
 });


### PR DESCRIPTION
Same changes applied on [this pull request](https://github.com/xmartlabs/blog/pull/75) but without the pagination.

**Fixes:**
- Remove horizontal scrolling on mobile that happens due to code sections (for example: [Introducing Fountain Part Two](https://blog.xmartlabs.com/2018/08/20/Introducing-Fountain-Part-Two/))

**Features:**
- Go to top button on mobile
![screen shot 2018-12-03 at 15 03 53](https://user-images.githubusercontent.com/15196342/49396079-01b8d900-f717-11e8-9585-9e99a93c78f1.png)
- README to explain local setup and how to change the featured posts