### PR TITLE
changes get in touch link to the contact page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -52,7 +52,7 @@ layout: default
         </div>
         <div class="get-in-touch">
           <img src="/images/logo.svg"/>
-          <a href="mailto:hi@xmartlabs.com?Subject=Hello%20Xmartlabs">
+          <a href="https://xmartlabs.com/contact">
             <span>Get in touch</span>
           </a>
         </div>
@@ -64,7 +64,7 @@ layout: default
           </div>
           <h1>Let's talk</h1>
           <p>{{ page.banner_message | default: "Interested in how we can help you?" }}</p>
-          <a href="mailto:hi@xmartlabs.com?Subject=Hello%20Xmartlabs">
+          <a href="https://xmartlabs.com/contact">
             <span>Get in touch</span>
           </a>
         </div>


### PR DESCRIPTION
Changed the Get In Touch link to `https://xmartlabs.com/contact` instead of a mailto link.